### PR TITLE
Agrega pruebas unitarias para AppointmentViewModel y una clase de pru…

### DIFF
--- a/app/src/test/java/com/dogAPPackage/dogapp/viewmodel/AppointmentViewModelTest.kt
+++ b/app/src/test/java/com/dogAPPackage/dogapp/viewmodel/AppointmentViewModelTest.kt
@@ -1,0 +1,147 @@
+package com.dogAPPackage.dogapp.viewmodel
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.Observer
+import com.dogAPPackage.dogapp.model.Appointment
+import com.dogAPPackage.dogapp.repository.AppointmentRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.*
+import org.junit.*
+import org.mockito.Mockito.*
+import org.mockito.kotlin.mock
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AppointmentViewModelTest {
+
+    @get:Rule
+    val instantExecutorRule = InstantTaskExecutorRule()
+
+    private lateinit var appointmentRepository: AppointmentRepository
+    private lateinit var viewModel: AppointmentViewModel
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        appointmentRepository = mock()
+        viewModel = AppointmentViewModel(appointmentRepository)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `getBreedsFromApi should update breedsList`() = runTest {
+        // Arrange
+        val mockBreeds = listOf("Labrador", "Poodle")
+        `when`(appointmentRepository.getAllBreeds()).thenReturn(mockBreeds)
+        val observer = mock<Observer<List<String>>>()
+        viewModel.breedsList.observeForever(observer)
+
+        // Act
+        viewModel.getBreedsFromApi()
+        advanceUntilIdle()
+
+        // Assert
+        verify(observer).onChanged(mockBreeds)
+        verify(appointmentRepository).getAllBreeds()
+
+        viewModel.breedsList.removeObserver(observer)
+    }
+
+    @Test
+    fun `saveAppointment should update saveResult to true`() = runTest {
+        // Arrange
+        val mockAppointment = Appointment(
+            id = "1",
+            petName = "Firulais",
+            breed = "Labrador",
+            ownerName = "Juan",
+            phone = "1234567890",
+            symptom = "Fiebre",
+            imageUrl = "http://example.com/image.jpg"
+        )
+        `when`(appointmentRepository.saveAppointment(mockAppointment)).thenReturn("1")
+        val observer = mock<Observer<Boolean>>()
+        viewModel.saveResult.observeForever(observer)
+
+        // Act
+        viewModel.saveAppointment(mockAppointment)
+        advanceUntilIdle()
+
+        // Assert
+        verify(observer).onChanged(true)
+        verify(appointmentRepository).saveAppointment(mockAppointment)
+
+        viewModel.saveResult.removeObserver(observer)
+    }
+
+    @Test
+    fun `getRandomImageByBreed should update imageUrl`() = runTest {
+        // Arrange
+        val mockImageUrl = "https://example.com/dog.jpg"
+        `when`(appointmentRepository.getRandomImageByBreed("Labrador")).thenReturn(mockImageUrl)
+        val observer = mock<Observer<String?>>()
+        viewModel.imageUrl.observeForever(observer)
+
+        // Act
+        viewModel.getRandomImageByBreed("Labrador")
+        advanceUntilIdle()
+
+        // Assert
+        verify(observer).onChanged(mockImageUrl)
+        verify(appointmentRepository).getRandomImageByBreed("Labrador")
+
+        viewModel.imageUrl.removeObserver(observer)
+    }
+
+    @Test
+    fun `getListAppointments should update listAppointments`() = runTest {
+        // Arrange
+        val mockAppointments = listOf(
+            Appointment(id = "1", petName = "Rex"),
+            Appointment(id = "2", petName = "Luna")
+        )
+        `when`(appointmentRepository.getListAppointment()).thenReturn(mockAppointments)
+        val observer = mock<Observer<List<Appointment>>>()
+        viewModel.listAppointments.observeForever(observer)
+
+        // Act
+        viewModel.getListAppointments()
+        advanceUntilIdle()
+
+        // Assert
+        verify(observer).onChanged(mockAppointments)
+        verify(appointmentRepository).getListAppointment()
+
+        viewModel.listAppointments.removeObserver(observer)
+    }
+
+    @Test
+    fun `deleteAppointment should update operationSuccess to true`() = runTest {
+        // Arrange
+        val mockAppointment = Appointment(
+            id = "1",
+            petName = "Firulais",
+            breed = "Labrador",
+            ownerName = "Juan"
+        )
+        val observer = mock<Observer<Boolean?>>()
+        viewModel.operationSuccess.observeForever(observer)
+
+        // Act
+        viewModel.deleteAppointment(mockAppointment)
+        advanceUntilIdle()
+
+        // Assert
+        verify(observer).onChanged(true)
+        verify(appointmentRepository).deleteAppointment(mockAppointment)
+
+        viewModel.operationSuccess.removeObserver(observer)
+    }
+
+}

--- a/app/src/test/java/com/dogAPPackage/dogapp/viewmodel/LoginViewModelTest.kt
+++ b/app/src/test/java/com/dogAPPackage/dogapp/viewmodel/LoginViewModelTest.kt
@@ -1,0 +1,12 @@
+package com.dogAPPackage.dogapp.viewmodel
+
+import org.junit.Assert.*
+import org.junit.Before
+
+class LoginViewModelTest {
+    @Before
+    fun setUp() {
+        TODO("Not yet implemented")
+    }
+
+}


### PR DESCRIPTION
…eba vacía para LoginViewModel.

Se crearon pruebas para verificar la funcionalidad de los siguientes métodos en AppointmentViewModel:
- `getBreedsFromApi`
- `saveAppointment`
- `getRandomImageByBreed`
- `getListAppointments`
- `deleteAppointment`

Se utiliza Mockito para simular el comportamiento del `AppointmentRepository` y `InstantTaskExecutorRule` junto con `TestCoroutineDispatcher` para manejar las coroutines y LiveData en las pruebas.